### PR TITLE
Add email settings to administration

### DIFF
--- a/src/i18n/en/admin.js
+++ b/src/i18n/en/admin.js
@@ -630,6 +630,16 @@ export default {
           title: 'Mail',
           'from-address': 'Sender address',
           'from-name': 'Sender name',
+          emailConfirmation: {
+            title: 'Email Confirmation',
+            subject: 'Subject',
+            body: 'Body',
+          },
+          passwordReset: {
+            title: 'Password Reset',
+            subject: 'Subject',
+            body: 'Body',
+          },
         },
       },
     },
@@ -685,6 +695,11 @@ export default {
           'max-length': 'Number of characters shown in the notification',
         },
       },
+    },
+    mail: {
+      title: 'Email',
+      header: 'Header (EmailHeaderEn):',
+      footer: 'Footer (EmailFooterEn):',
     },
   },
   general: {

--- a/src/views/Settings/Auth.vue
+++ b/src/views/Settings/Auth.vue
@@ -72,6 +72,38 @@
           </b-input-group>
         </b-form-group>
       </b-form-group>
+
+      <b-form-group :label="$t('settings.system.auth.mail.emailConfirmation.title')" label-size="lg">
+        <b-form-group :label="$t('settings.system.auth.mail.emailConfirmation.subject')" label-cols="2">
+          <b-input-group>
+            <b-form-input v-model="settings['auth.mail.email-confirmation.subject.en']" />
+          </b-input-group>
+        </b-form-group>
+
+        <b-form-group :label="$t('settings.system.auth.mail.emailConfirmation.body')" label-cols="2">
+          <b-input-group>
+            <b-form-textarea v-model="settings['auth.mail.email-confirmation.body.en']"
+                             class="overflow-auto"
+                             max-rows="20" />
+          </b-input-group>
+        </b-form-group>
+      </b-form-group>
+
+      <b-form-group :label="$t('settings.system.auth.mail.passwordReset.title')" label-size="lg">
+        <b-form-group :label="$t('settings.system.auth.mail.passwordReset.subject')" label-cols="2">
+          <b-input-group>
+            <b-form-input v-model="settings['auth.mail.password-reset.subject.en']" />
+          </b-input-group>
+        </b-form-group>
+
+        <b-form-group :label="$t('settings.system.auth.mail.passwordReset.body')" label-cols="2">
+          <b-input-group>
+            <b-form-textarea v-model="settings['auth.mail.password-reset.body.en']"
+                             class="overflow-auto"
+                             max-rows="20" />
+          </b-input-group>
+        </b-form-group>
+      </b-form-group>
     </main>
 
     <div class="text-right">

--- a/src/views/Settings/Compose.vue
+++ b/src/views/Settings/Compose.vue
@@ -31,7 +31,7 @@
                       label-cols="2">
 
           <b-input-group class="m-0">
-            <b-form-input v-model="settings['file.type.whitelist']" />
+            <b-form-input v-model="fileWhitelist" />
           </b-input-group>
         </b-form-group>
       </b-form-group>
@@ -55,6 +55,22 @@ export default {
     }
   },
 
+  computed: {
+    fileWhitelist: {
+      get () {
+        return (this.settings['file.type.whitelist'] || []).join(',')
+      },
+
+      set (value) {
+        this.settings['file.type.whitelist'] = (value || '').split(',').map(v => {
+          return v.replace(/ /g, '')
+        }).filter(v => {
+          return v
+        })
+      },
+    },
+  },
+
   created () {
     this.fetchSettings()
   },
@@ -68,7 +84,7 @@ export default {
         return { name, value }
       })
 
-      this.$SystemAPI.settingsUpdate({ values })
+      this.$ComposeAPI.settingsUpdate({ values })
         .catch(this.stdReject)
         .finally(this.finalize)
     },

--- a/src/views/Settings/Email.vue
+++ b/src/views/Settings/Email.vue
@@ -1,0 +1,96 @@
+<template>
+  <b-form @submit.prevent="onSubmit" class="overflow-hidden">
+    <router-link :to="{ name: 'settings' }" class="float-right pr-1"><b-button-close></b-button-close></router-link>
+    <div class="header">
+      <h2 class="header-subtitle header-row">
+        {{ $t('settings.mail.title') }}
+      </h2>
+    </div>
+
+    <hr />
+
+    <main>
+      <b-form-group :label="$t('settings.mail.header')" label-cols="2">
+        <b-input-group>
+          <b-form-textarea v-model="settings['mail.header.en']"
+                           class="overflow-auto"
+                           max-rows="20" />
+
+        </b-input-group>
+      </b-form-group>
+
+      <b-form-group :label="$t('settings.mail.footer')" label-cols="2">
+        <b-input-group>
+          <b-form-textarea v-model="settings['mail.footer.en']"
+                           class="overflow-auto"
+                           max-rows="20" />
+        </b-input-group>
+      </b-form-group>
+    </main>
+
+    <div class="text-right">
+      <b-button type="submit" variant="primary">{{ $t('general.label.saveChanges') }}</b-button>
+    </div>
+  </b-form>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      processing: true,
+
+      error: null,
+
+      settings: {},
+    }
+  },
+
+  created () {
+    this.fetchSettings()
+  },
+
+  methods: {
+    onSubmit () {
+      // Collect changed variables
+      this.processing = true
+
+      const values = Object.entries(this.settings).map(([name, value]) => {
+        return { name, value }
+      })
+
+      this.$SystemAPI.settingsUpdate({ values })
+        .catch(this.stdReject)
+        .finally(this.finalize)
+    },
+
+    fetchSettings () {
+      this.processing = true
+
+      this.$SystemAPI.settingsList({ prefix: 'mail.' }).then(vv => {
+        vv.forEach(({ name, value }) => {
+          this.$set(this.settings, name, value)
+        })
+      })
+        .catch(this.stdReject)
+        .finally(this.finalize)
+    },
+
+    stdReject ({ message }) {
+      this.error = message
+    },
+
+    finalize () {
+      this.processing = false
+    },
+  },
+}
+</script>
+<style scoped lang="scss">
+main {
+  height: auto;
+  max-height: 80vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+</style>

--- a/src/views/Settings/Index.vue
+++ b/src/views/Settings/Index.vue
@@ -6,6 +6,7 @@
         <router-link :to="{ name: 'external-providers' }">{{ $t('settings.system.auth.external-providers.title') }}</router-link>
         <router-link :to="{ name: 'compose' }">{{ $t('settings.compose.title') }}</router-link>
         <router-link :to="{ name: 'messaging' }">{{ $t('settings.messaging.title') }}</router-link>
+        <router-link :to="{ name: 'email' }">{{ $t('settings.mail.title') }}</router-link>
       </li>
     </ul>
   </list-with-details>

--- a/src/views/Settings/Messaging.vue
+++ b/src/views/Settings/Messaging.vue
@@ -45,7 +45,7 @@
                       :description="$t('settings.messaging.message.attachment.type.description')"
                       label-cols="2">
           <b-input-group class="m-0">
-            <b-form-input v-model="settings['message.attachment.type.whitelist']" />
+            <b-form-input v-model="attachmentWhitelist" />
           </b-input-group>
         </b-form-group>
       </b-form-group>
@@ -96,6 +96,22 @@ export default {
     }
   },
 
+  computed: {
+    attachmentWhitelist: {
+      get () {
+        return (this.settings['message.attachment.type.whitelist'] || []).join(',')
+      },
+
+      set (value) {
+        this.settings['message.attachment.type.whitelist'] = (value || '').split(',').map(v => {
+          return v.replace(/ /g, '')
+        }).filter(v => {
+          return v
+        })
+      },
+    },
+  },
+
   created () {
     this.fetchSettings()
   },
@@ -109,7 +125,7 @@ export default {
         return { name, value }
       })
 
-      this.$SystemAPI.settingsUpdate({ values })
+      this.$ComposeAPI.settingsUpdate({ values })
         .catch(this.stdReject)
         .finally(this.finalize)
     },

--- a/src/views/routes.js
+++ b/src/views/routes.js
@@ -21,6 +21,7 @@ export default [
           { path: 'external-providers', name: 'external-providers', component: view('Settings/External'), props: true, canReuse: false },
           { path: 'compose', name: 'compose', component: view('Settings/Compose'), props: true, canReuse: false },
           { path: 'messaging', name: 'messaging', component: view('Settings/Messaging'), props: true, canReuse: false },
+          { path: 'email', name: 'email', component: view('Settings/Email'), props: true, canReuse: false },
         ],
       },
       { path: 'roles',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2831,8 +2831,8 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 corteza-webapp-common@cortezaproject/corteza-webapp-common.git#master:
-  version "2019.9.0-rc.37"
-  resolved "https://codeload.github.com/cortezaproject/corteza-webapp-common/tar.gz/09b1c189aae349a17392df4c77998eaff192c7a5"
+  version "2019.9.0-rc.38"
+  resolved "https://codeload.github.com/cortezaproject/corteza-webapp-common/tar.gz/bf1a5739c4e355af9f96f6c70e2a91d57174ee92"
   dependencies:
     diff "4.0.1"
     mime-types "2.1.24"


### PR DESCRIPTION
*Ref: https://github.com/cortezaproject/corteza-webapp-admin/pull/16*

For now, we will provide simple text-area email template editing. Later this should be improved with a proper editor.

**Root-level email editing:**
*Edit base header/footer - edited: added template key, making it clearer, what you are editing*
![Screenshot from 2019-10-17 11-21-40](https://user-images.githubusercontent.com/12545711/66996081-57e4ff80-f0d0-11e9-8cf0-069423207091.png)

**Auth-level email editing:**
*Edit auth related emails*
![Screenshot from 2019-10-17 10-49-11](https://user-images.githubusercontent.com/12545711/66993488-f0c54c00-f0cb-11e9-9e65-75b1ea051542.png)
