### PR TITLE
Fix authclient prohibited roles

### DIFF
--- a/src/components/Authclient/CAuthclientEditorInfo.vue
+++ b/src/components/Authclient/CAuthclientEditorInfo.vue
@@ -352,16 +352,16 @@ curl -X POST {{ curlURL }} \
       </b-form-group>
 
       <b-form-group
-        :label="$t('security.forbiddenRoles.label')"
+        :label="$t('security.prohibitedRoles.label')"
         label-cols="3"
         class="mb-0"
       >
         <c-role-picker
-          v-model="authClient.security.forbiddenRoles"
+          v-model="authClient.security.prohibitedRoles"
           class="mb-3"
         >
           <template #description>
-            {{ $t('security.forbiddenRoles.description') }}
+            {{ $t('security.prohibitedRoles.description') }}
           </template>
         </c-role-picker>
       </b-form-group>
@@ -480,7 +480,7 @@ import axios from 'axios'
 const defSecurity = Object.freeze({
   impersonateUser: '0',
   permittedRoles: [],
-  forbiddenRoles: [],
+  prohibitedRoles: [],
   forcedRoles: [],
 })
 

--- a/src/components/Settings/System/Auth/ExternalOIDC.vue
+++ b/src/components/Settings/System/Auth/ExternalOIDC.vue
@@ -113,7 +113,7 @@ export default {
       scope,
 
       permittedRoles: [],
-      forbiddenRoles: [],
+      prohibitedRoles: [],
       forcedRoles: [],
     }
   },

--- a/src/components/Settings/System/Auth/ExternalSecurity.vue
+++ b/src/components/Settings/System/Auth/ExternalSecurity.vue
@@ -22,7 +22,7 @@
       class="mb-0"
     >
       <c-role-picker
-        v-model="value.forbiddenRoles"
+        v-model="value.prohibitedRoles"
         class="mb-3"
       >
         <template #description>

--- a/src/components/Settings/System/CSystemEditorExternal.vue
+++ b/src/components/Settings/System/CSystemEditorExternal.vue
@@ -112,7 +112,7 @@ const idpStandard = [
 
 const idpSecurity = {
   permittedRoles: [],
-  forbiddenRoles: [],
+  prohibitedRoles: [],
   forcedRoles: [],
 }
 


### PR DESCRIPTION
It renames the auth-client's security role list of `forbiddenRoles` to `prohibitedRoles` as per the server.

Please take a look.